### PR TITLE
refactor: テスト用定数ファイルを作成してモックデータの重複を解消

### DIFF
--- a/packages/backend/src/services/fileSystemService.test.ts
+++ b/packages/backend/src/services/fileSystemService.test.ts
@@ -10,6 +10,7 @@ import {
   getPathSuggestions,
   FileSystemError,
 } from './fileSystemService';
+import { MOCK_DIRECTORY_PERMISSIONS, MOCK_PATHS } from '../test/constants';
 
 describe('fileSystemService', () => {
   let tempDir: string;
@@ -31,15 +32,14 @@ describe('fileSystemService', () => {
 
   describe('resolvePath', () => {
     test('絶対パスはそのまま返す', () => {
-      const absolutePath = '/absolute/path';
-      const result = resolvePath(absolutePath);
+      const result = resolvePath(MOCK_PATHS.VALID_ABSOLUTE);
 
-      expect(result).toBe(absolutePath);
+      expect(result).toBe(MOCK_PATHS.VALID_ABSOLUTE);
     });
 
     test('絶対パスでない場合はエラーを投げる', () => {
-      expect(() => resolvePath('./relative/path')).toThrow(FileSystemError);
-      expect(() => resolvePath('~/home/path')).toThrow(FileSystemError);
+      expect(() => resolvePath(MOCK_PATHS.INVALID_RELATIVE)).toThrow(FileSystemError);
+      expect(() => resolvePath(MOCK_PATHS.INVALID_TILDE)).toThrow(FileSystemError);
       expect(() => resolvePath('relative/path')).toThrow(FileSystemError);
     });
 
@@ -110,11 +110,7 @@ describe('fileSystemService', () => {
     test('読み書き可能なディレクトリの場合は適切な権限情報を返す', async () => {
       const result = await checkDirectoryPermissions(tempDir);
 
-      expect(result).toEqual({
-        readable: true,
-        writable: true,
-        executable: true,
-      });
+      expect(result).toEqual(MOCK_DIRECTORY_PERMISSIONS.FULL_ACCESS);
     });
 
     test('存在しないディレクトリの場合はエラーを投げる', async () => {

--- a/packages/backend/src/test/constants.ts
+++ b/packages/backend/src/test/constants.ts
@@ -1,0 +1,182 @@
+/**
+ * テスト用の定数とモックデータ
+ *
+ * テストファイル間でのモックデータの重複を避けるため、
+ * 共通で使用するモックデータと定数をここに集約します。
+ */
+
+import type { AppConfig, ProjectInfo } from '@kiro-lens/shared';
+
+// ===== ファイルシステム関連のモック戻り値 =====
+
+/**
+ * ファイルシステム操作の成功時モック戻り値
+ */
+export const MOCK_FS_SUCCESS = {
+  /** fs.access の成功時戻り値 */
+  ACCESS_SUCCESS: undefined,
+  /** fs.mkdir の成功時戻り値 */
+  MKDIR_SUCCESS: undefined,
+  /** fs.writeFile の成功時戻り値 */
+  WRITE_FILE_SUCCESS: undefined,
+  /** fs.chmod の成功時戻り値 */
+  CHMOD_SUCCESS: undefined,
+} as const;
+
+/**
+ * ファイルシステム操作のエラー時モック戻り値
+ */
+export const MOCK_FS_ERRORS = {
+  /** ファイル/ディレクトリが存在しない場合のエラー */
+  ENOENT: new Error('ENOENT'),
+  /** 権限不足エラー */
+  PERMISSION_DENIED: new Error('Permission denied'),
+  /** 無効なJSON */
+  INVALID_JSON: 'invalid json',
+} as const;
+
+/**
+ * ディレクトリ権限情報のモック
+ */
+export const MOCK_DIRECTORY_PERMISSIONS = {
+  /** 全権限あり */
+  FULL_ACCESS: {
+    readable: true,
+    writable: true,
+    executable: true,
+  },
+  /** 読み取り権限なし */
+  NO_READ_ACCESS: {
+    readable: false,
+    writable: true,
+    executable: true,
+  },
+  /** 書き込み権限なし */
+  NO_WRITE_ACCESS: {
+    readable: true,
+    writable: false,
+    executable: true,
+  },
+} as const;
+
+// ===== 設定関連のモックデータ =====
+
+/**
+ * テスト用のデフォルト設定
+ */
+export const MOCK_DEFAULT_CONFIG: AppConfig = {
+  version: '1.0.0',
+  projects: [],
+  settings: {
+    theme: 'system',
+    autoSave: true,
+    maxRecentProjects: 10,
+  },
+  metadata: {
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    configPath: '/home/test/.kiro-lens/config.json',
+  },
+};
+
+/**
+ * テスト用のカスタム設定
+ */
+export const MOCK_CUSTOM_CONFIG: AppConfig = {
+  version: '1.0.0',
+  projects: [],
+  settings: {
+    theme: 'dark',
+    autoSave: false,
+    maxRecentProjects: 5,
+  },
+  metadata: {
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    configPath: '/home/test/.kiro-lens/config.json',
+  },
+};
+
+// ===== プロジェクト関連のモックデータ =====
+
+/**
+ * テスト用のプロジェクト情報
+ */
+export const MOCK_PROJECT: ProjectInfo = {
+  id: 'test-project-id',
+  name: 'test-project',
+  path: '/absolute/path/to/project',
+  kiroPath: '/absolute/path/to/project/.kiro',
+  hasKiroDir: true,
+  isValid: true,
+  addedAt: '2024-01-01T00:00:00.000Z',
+};
+
+/**
+ * テスト用の無効なプロジェクト情報
+ */
+export const MOCK_INVALID_PROJECT: ProjectInfo = {
+  ...MOCK_PROJECT,
+  id: 'invalid-project-id',
+  name: 'invalid-project',
+  path: '/absolute/path/to/invalid',
+  kiroPath: '/absolute/path/to/invalid/.kiro',
+  hasKiroDir: false,
+  isValid: false,
+};
+
+/**
+ * プロジェクトを含む設定
+ */
+export const MOCK_CONFIG_WITH_PROJECT: AppConfig = {
+  ...MOCK_DEFAULT_CONFIG,
+  projects: [MOCK_PROJECT],
+};
+
+/**
+ * 選択されたプロジェクトを含む設定
+ */
+export const MOCK_CONFIG_WITH_SELECTED_PROJECT: AppConfig = {
+  ...MOCK_CONFIG_WITH_PROJECT,
+  settings: {
+    ...MOCK_DEFAULT_CONFIG.settings,
+    lastSelectedProject: MOCK_PROJECT.id,
+  },
+};
+
+// ===== テスト用のパス定数 =====
+
+/**
+ * テスト用のパス定数
+ */
+export const MOCK_PATHS = {
+  /** 有効な絶対パス */
+  VALID_ABSOLUTE: '/absolute/path/to/project',
+  /** 無効な相対パス */
+  INVALID_RELATIVE: './relative/path',
+  /** 無効なチルダパス */
+  INVALID_TILDE: '~/home/path',
+  /** 存在しないパス */
+  NON_EXISTENT: '/absolute/path/to/nonexistent',
+  /** テスト用設定パス */
+  TEST_CONFIG: '/home/test/.kiro-lens/config.json',
+} as const;
+
+// ===== UUID関連のモック =====
+
+/**
+ * テスト用のUUID
+ */
+export const MOCK_UUID = 'test-uuid-123';
+
+// ===== 日時関連のモック =====
+
+/**
+ * テスト用の固定日時
+ */
+export const MOCK_DATE = '2024-01-01T00:00:00.000Z';
+
+/**
+ * テスト用の日時オブジェクト
+ */
+export const MOCK_DATE_OBJECT = new Date(MOCK_DATE);


### PR DESCRIPTION
# テスト用定数ファイルを作成してモックデータの重複を解消

## 変更内容

### 新規作成

- `packages/backend/src/test/constants.ts` - テスト用定数ファイル

### 修正ファイル

- `packages/backend/src/services/configService.test.ts` - モックデータを定数に置き換え
- `packages/backend/src/services/projectService.test.ts` - モックデータを定数に置き換え
- `packages/backend/src/services/fileSystemService.test.ts` - 一部の定数を使用するよう改善

## 変更理由

バックエンドのサービステストで同じモックデータが複数箇所で重複していたため、保守性とDRY原則の観点から改善が必要でした。

### 重複していたモックデータ

- ファイルシステム操作の戻り値（`mockFs.access.mockResolvedValue(undefined)` など）
- 設定データ（`AppConfig`オブジェクト）
- プロジェクト情報（`ProjectInfo`オブジェクト）
- ディレクトリ権限情報
- エラーオブジェクト

## 影響範囲

- **バックエンドテスト**: 全57個のテストが正常に通過
- **フロントエンドテスト**: 影響なし（21個のテストが正常に通過）
- **共通パッケージ**: 影響なし

## テスト結果

```bash
✓ packages/backend/src/services/configService.test.ts (14 tests)
✓ packages/backend/src/services/fileSystemService.test.ts (15 tests)
✓ packages/backend/src/services/projectService.test.ts (19 tests)
✓ packages/backend/src/error-handling.test.ts (3 tests)
✓ packages/backend/src/cors.test.ts (3 tests)
✓ packages/backend/src/routes/project.test.ts (3 tests)

Test Files  6 passed (6)
Tests  57 passed (57)
```

## 品質チェック

- ✅ ESLint: エラーなし
- ✅ Prettier: フォーマット適用済み
- ✅ TypeScript: コンパイルエラーなし

## 実装詳細

### 定数ファイルの構成

```typescript
// ファイルシステム関連
export const MOCK_FS_SUCCESS = {
  ACCESS_SUCCESS: undefined,
  MKDIR_SUCCESS: undefined,
  WRITE_FILE_SUCCESS: undefined,
  CHMOD_SUCCESS: undefined,
} as const;

// 設定関連
export const MOCK_DEFAULT_CONFIG: AppConfig = { ... };
export const MOCK_CUSTOM_CONFIG: AppConfig = { ... };

// プロジェクト関連
export const MOCK_PROJECT: ProjectInfo = { ... };
export const MOCK_INVALID_PROJECT: ProjectInfo = { ... };
```

### 改善効果

1. **保守性向上**: モックデータの変更が1箇所で済む
2. **DRY原則適用**: 重複コードを削除
3. **可読性向上**: テストコードが簡潔に
4. **一貫性確保**: 全テストで同じデータを使用

## チェックリスト

### TypeScript

- [x] 型安全性が保たれている
- [x] `any`型の使用を避けている
- [x] 適切な型定義がされている

### テスト

- [x] 全テストが通過している
- [x] テストの意図が明確
- [x] 保守しやすい構造

### コード品質

- [x] DRY原則に従っている
- [x] 適切なコメントが記述されている
- [x] ESLintチェック通過
- [x] Prettierフォーマット適用済み
