### PR TITLE
[feat] FileTreeResponse型の実装とsharedパッケージの型定義拡張

### DIFF
--- a/.kiro/specs/file-tree-system/tasks.md
+++ b/.kiro/specs/file-tree-system/tasks.md
@@ -6,7 +6,7 @@
 
 ## TDD実装タスク
 
-- [ ] 1. 共通型定義の拡張（TDD）
+- [x] 1. 共通型定義の拡張（TDD）
   - shared パッケージにFileTreeResponse型を追加
   - 既存のFileItem型との統合確認
   - TypeScriptコンパイルエラーなしを確認

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,7 @@ export type {
   AddProjectResponse,
   ProjectListResponse,
   ValidationResult,
+  FileTreeResponse,
 } from './types/api';
 
 // プロジェクト関連型定義

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -1,6 +1,7 @@
 // API関連の型定義
 
 import type { ProjectInfo } from './project';
+import type { FileItem } from './file-tree';
 
 /**
  * APIエラータイプ
@@ -120,4 +121,15 @@ export interface ValidationResult {
   readonly error?: string;
   /** 検証されたパス（成功時） */
   readonly validatedPath?: string;
+}
+
+/**
+ * ファイルツリーレスポンス
+ *
+ * GET /api/projects/:id/files エンドポイントのレスポンス形式を定義します。
+ * 既存のFileItem型を使用してファイル構造を表現します。
+ */
+export interface FileTreeResponse {
+  /** プロジェクトの.kiro配下のファイル構造 */
+  readonly files: FileItem[];
 }


### PR DESCRIPTION
# FileTreeResponse型の実装とsharedパッケージの型定義拡張

## 変更内容

### 主な変更

- **FileTreeResponse型の追加**: `packages/shared/src/types/api.ts`にファイルツリーAPI用の型定義を追加
- **既存型との統合**: 既存の`FileItem`型を活用してファイル構造を表現
- **エクスポート構造の更新**: `packages/shared/src/index.ts`で新しい型をエクスポート

### 実装詳細

- `FileTreeResponse`インターフェースを作成
- `GET /api/projects/:id/files`エンドポイント用のレスポンス形式を定義
- 既存の`FileItem`型との統合により一貫性のある型システムを実現
- シンプルな`readonly files: FileItem[]`形式で冗長性を排除

## 変更理由

file-tree-systemスペックのタスク1「共通型定義の拡張（TDD）」の実装として、ファイルツリー機能に必要な型定義を追加しました。既存の型システムとの整合性を保ちながら、将来のファイルツリー機能実装の基盤を整備しています。

## 影響範囲

- **sharedパッケージ**: 新しい型定義の追加
- **型安全性**: FileTreeResponse型によるAPI レスポンスの型安全性向上
- **後方互換性**: 既存の型定義に影響なし

## テスト

- TypeScriptコンパイルエラーなしを確認
- 全パッケージ（shared、backend、frontend）でビルド成功
- 既存テストの継続実行を確認

## チェックリスト

- [x] 要件4.1に完全対応
- [x] 既存のFileItem型との統合確認
- [x] TypeScriptコンパイルエラーなし
- [x] エクスポート構造の適切な更新
- [x] 型定義のテストは作成せず（テストガイドライン準拠）
